### PR TITLE
Resolve issues with stuck buttons on some touch devices

### DIFF
--- a/src/js/piano-genie.js
+++ b/src/js/piano-genie.js
@@ -397,6 +397,12 @@ export function initPianoGenie(options) {
     document.addEventListener('keydown',onKeyDown);
 
     const eventListenerOptions = {passive: false};
+    const preventDefault = (e) => e.preventDefault();
+
+    // Prevent the context menu where possible.
+    const canvas = document.getElementById('canvas');
+    canvas.addEventListener('contextmenu', preventDefault, eventListenerOptions);
+    window.addEventListener('contextmenu', preventDefault, eventListenerOptions);
 
     // Allow the user to press anywhere to start, not just on the buttons.
     // (Implicit pointer capture on touch devices would prevent this.)
@@ -420,6 +426,9 @@ export function initPianoGenie(options) {
     const ignoreHover = (cb) => e => e.buttons !== 0 ? cb(e) : noop();
     const buttons = document.querySelectorAll(".keyboard button.color");
     for(const button of buttons) {
+      // Prevent accidental section of elements and texts.
+      button.addEventListener('pointerdown', preventDefault, eventListenerOptions);
+
       // Browsers that support direct manipulation (e.g. most browser on mobile devices)
       // trigger implicit pointer capture on a `pointerdown` event. This prevents
       // `pointerover` and `pointerout` from firing, so we need to manually release the

--- a/src/js/piano-genie.js
+++ b/src/js/piano-genie.js
@@ -396,15 +396,42 @@ export function initPianoGenie(options) {
 
     document.addEventListener('keydown',onKeyDown);
 
+    const eventListenerOptions = {passive: false};
+
+    // Allow the user to press anywhere to start, not just on the buttons.
+    // (Implicit pointer capture on touch devices would prevent this.)
+    window.addEventListener('pointerdown', (e) => e.target.releasePointerCapture(e.pointerId));
+
+    // Clean up pointers that don't end on the button bar.
+    const releasePointer = (event) => {
+      const inputString = `pointer_${event.pointerId}`;
+      for( let i = 0; i < NUM_BUTTONS; i+= 1) {
+        doInputEnd({buttonId: `${i}`, inputString});
+      }
+    }
+    window.addEventListener('pointercancel', releasePointer, eventListenerOptions);
+    window.addEventListener('pointerup', releasePointer, eventListenerOptions);
+
+    const releasePointerCapture = (event) => {
+      event.target.releasePointerCapture(event.pointerId);
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    };
     const noop = () => {};
-    const filterActivePointer = (cb) => e => e.buttons !== 0 ? cb(e) : noop();
+    const ignoreHover = (cb) => e => e.buttons !== 0 ? cb(e) : noop();
     const buttons = document.querySelectorAll(".keyboard button.color");
     for(const button of buttons) {
-      button.addEventListener('pointercancel', doPointerStart);
-      button.addEventListener('pointerdown', doPointerStart);
-      button.addEventListener('pointerup', doPointerEnd);
-      button.addEventListener('pointerover', filterActivePointer(doPointerStart));
-      button.addEventListener('pointerout', filterActivePointer(doPointerEnd));
+      // Browsers that support direct manipulation (e.g. most browser on mobile devices)
+      // trigger implicit pointer capture on a `pointerdown` event. This prevents
+      // `pointerover` and `pointerout` from firing, so we need to manually release the
+      // pointer capture on `pointerdown`.
+      button.addEventListener('pointerdown', releasePointerCapture, eventListenerOptions);
+
+      // Manage pointer lifecycle for each button.
+      button.addEventListener('pointercancel', releasePointer, eventListenerOptions);
+      button.addEventListener('pointerdown', doPointerStart, eventListenerOptions);
+      button.addEventListener('pointerup', releasePointer, eventListenerOptions);
+      button.addEventListener('pointerover', ignoreHover(doPointerStart), eventListenerOptions);
+      button.addEventListener('pointerout', doPointerEnd, eventListenerOptions);
     }
 
     // Output.
@@ -474,8 +501,9 @@ export function initPianoGenie(options) {
   }
 
   function preprocessPointerEvent(event) {
-    event.preventDefault();
-    const buttonId = event.target.dataset.id;
+    // We want the element to which the event handler has been attached,
+    // so we use `currentTarget` instead of `target`.
+    const buttonId = event.currentTarget.dataset.id;
     const inputString = `pointer_${event.pointerId}`;
     return {buttonId, inputString};
   }
@@ -504,8 +532,10 @@ export function initPianoGenie(options) {
       inputsForButtons.set(buttonId, new Set());
     }
     const inputsForButton = inputsForButtons.get(buttonId);
+    const wasHolding = inputsForButton.has(inputString);
     inputsForButton.delete(inputString)
-    if(inputsForButton.size === 0) {
+    // Only release button if it hasn't already been released before.
+    if(wasHolding && inputsForButton.size === 0) {
       buttonUp(buttonId);
     }
   }

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -24,7 +24,12 @@ body {
   overflow: auto;
 }
 
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+  -webkit-user-select: none; /* Safari */
+  -ms-user-select: none; /* IE 10 and IE 11 */
+  user-select: none; /* Standard syntax */
+}
 [hidden] { display: none !important; }
 [disabled] { pointer-events: none; opacity: 0.3; }
 


### PR DESCRIPTION
This set of patches fixes various input pointer edge cases and brings back button slide support.

Fixed edge cases:
- Implicit pointer capture in browsers with direct manipulation support
- Certain pointer lifecycle event being fired on the "wrong" elements (it's probably in line with the spec, but still intuitively wrong)
- Sliding over the buttons to trigger button presses now works

In addition, context menus are now shown less often.

However, on Apple devices, I was not able to fix all issues related to long presses, i.e. long presses on texts automatically may open the dictionary (macOS) or show a magnifier (i(Pad)Os). If it is possible to disable such behavior as well, you may add it to this patch set. I couldn't figure out how to do it.

Note that the commits do not include the build results. If required, I can add them to each commit or we put one commit that updates the build results on top (e.g. into the merge commit).